### PR TITLE
Introduce a separate timeseer_network role

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+.ansible/
 settings.json
 venv/

--- a/timeseer/docker/roles/timeseer/meta/main.yml
+++ b/timeseer/docker/roles/timeseer/meta/main.yml
@@ -1,4 +1,5 @@
-dependencies: []
+dependencies:
+  - role: timeseer_network
 galaxy_info:
   author: Jeroen Hoekx, Diogo Lobo
   role_name: timeseer

--- a/timeseer/docker/roles/timeseer/tasks/main.yml
+++ b/timeseer/docker/roles/timeseer/tasks/main.yml
@@ -23,10 +23,6 @@
     timeseer_storage_mount: "{{ timeseer_db_dir }}/db"
   when: timeseer_docker_volume | default('') | trim == ''
 
-- name: Create a Docker network
-  community.docker.docker_network:
-    name: "{{ timeseer_network }}"
-
 - name: Download demo data
   community.docker.docker_container:
     name: timeseer-demo-data

--- a/timeseer/docker/roles/timeseer_data_service/README.md
+++ b/timeseer/docker/roles/timeseer_data_service/README.md
@@ -11,6 +11,7 @@ This Ansible role is designed to deploy and configure the Timeseer Data Service 
 - Ansible 2.9 or higher.
 - Docker installed on the target machine.
 - `community.docker` Ansible collection.
+
 ## Role Overview
 
 The Timeseer data service is an optional component specifically designed to enhance performance for data services in fleet scenarios. This service operates independently and has its own dedicated configuration file.

--- a/timeseer/docker/roles/timeseer_data_service/meta/main.yml
+++ b/timeseer/docker/roles/timeseer_data_service/meta/main.yml
@@ -1,4 +1,5 @@
-dependencies: []
+dependencies:
+  - role: timeseer_network
 galaxy_info:
   author: Jeroen Hoekx, Diogo Lobo
   role_name: timeseer_data_service

--- a/timeseer/docker/roles/timeseer_network/README.md
+++ b/timeseer/docker/roles/timeseer_network/README.md
@@ -1,0 +1,40 @@
+# Ansible Role: timeseer_network
+
+[![Ansible Galaxy](https://img.shields.io/badge/ansible--galaxy-timeseer_data_service-yellow.svg)](https://galaxy.ansible.com/ui/namespaces/timeseer/)
+
+This role creates a Docker network that is used by the containers started by the `timeseer`, `timeseer_reverse_proxy` and `timeseer_data_service` roles.
+
+## Requirements
+
+- Ansible 2.9 or higher.
+- Docker installed on the target machine.
+- `community.docker` Ansible collection.
+
+## Role Overview
+
+This role is used automatically by the roles that define containers.
+
+To include it manually:
+
+```yaml
+- name: Define a network for the Timeseer containers
+  ansible.builtin.import_role:
+    name: "timeseer.docker.timeseer_network"
+```
+## Role Variables
+
+Variables used in this role are listed below, along with default values (see `defaults/main.yml`):
+
+- `timeseer_network_name` (default: `"timeseer"`): docker network to which the containers will connect.
+
+## Dependencies
+
+There are no external role dependencies for this role, but Docker must be installed and operational on the target hosts.
+
+## License
+
+Refer to the `LICENSE.md` file in this repository for licensing information.
+
+## Author Information
+
+This role was created in 2025 by Timeseer.

--- a/timeseer/docker/roles/timeseer_network/defaults/main.yml
+++ b/timeseer/docker/roles/timeseer_network/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+timeseer_network_name: "timeseer"

--- a/timeseer/docker/roles/timeseer_network/meta/argument_specs.yml
+++ b/timeseer/docker/roles/timeseer_network/meta/argument_specs.yml
@@ -1,0 +1,12 @@
+argument_specs:
+  main:
+    short_description: Define a Docker network for Timeseer containers
+    description:
+      - Prepares a Docker network for use by the other Timeseer containers.
+
+    options:
+      timeseer_network_name:
+        description:
+          - The name of the Docker network use for Timeseer.
+        type: str
+        default: "timeseer"

--- a/timeseer/docker/roles/timeseer_network/tasks/main.yml
+++ b/timeseer/docker/roles/timeseer_network/tasks/main.yml
@@ -1,0 +1,3 @@
+- name: Create a Docker network
+  community.docker.docker_network:
+    name: "{{ timeseer_network_name }}"

--- a/timeseer/docker/roles/timeseer_reverse_proxy/meta/main.yml
+++ b/timeseer/docker/roles/timeseer_reverse_proxy/meta/main.yml
@@ -1,4 +1,5 @@
-dependencies: []
+dependencies:
+  - role: timeseer_network
 galaxy_info:
   author: Jeroen Hoekx, Diogo Lobo
   role_name: timeseer_reverse_proxy

--- a/timeseer/docker/roles/traefik/meta/main.yml
+++ b/timeseer/docker/roles/traefik/meta/main.yml
@@ -1,4 +1,5 @@
-dependencies: []
+dependencies:
+  - role: timeseer_network
 galaxy_info:
   author: Jeroen Hoekx, Diogo Lobo
   role_name: traefik


### PR DESCRIPTION
The network was previously created by the timeseer role. This allows reordering the roles.